### PR TITLE
Modernize using clang tidy and support GCC 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
           packages:
             - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=OFF BUILD_TYPE=Debug Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS=OFF
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=OFF BUILD_TYPE=Debug
     - os: linux
       addons:
         apt:
@@ -58,7 +58,7 @@ matrix:
           packages:
             - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=OFF BUILD_TYPE=Release Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS=OFF
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=OFF BUILD_TYPE=Release
     - os: linux
       addons:
         apt:
@@ -67,7 +67,7 @@ matrix:
           packages:
             - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=ON BUILD_TYPE=Debug Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS=OFF
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=ON BUILD_TYPE=Debug
     - os: linux
       addons:
         apt:
@@ -76,7 +76,7 @@ matrix:
           packages:
             - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=ON BUILD_TYPE=Release Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS=OFF
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=ON BUILD_TYPE=Release
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,47 @@ addons:
       - ninja
     update: true
 
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=OFF BUILD_TYPE=Debug Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS=OFF
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=OFF BUILD_TYPE=Release Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS=OFF
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=ON BUILD_TYPE=Debug Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS=OFF
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7" SHARED_LIB=ON BUILD_TYPE=Release Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS=OFF
+
 before_install:
+  - eval "${MATRIX_EVAL}"
   - echo ${DEPS_DIR}
   - mkdir -p ${DEPS_DIR}
   - pushd ${DEPS_DIR}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.4.4] - 2020-03-28
+## [1.4.4] - 2020-03-29
 
 ## Fixed
 
 - Minor fix to the parser (#37)
 
-## Updated
+## Changed
 
 - Updated the coverage of the web platform tests (#39)
+- String literal operators throw exceptions now (#42)
 
 ## [1.4.3] - 2020-03-18
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(Skyr_FULL_WARNINGS "Build the library with all warnings turned on." ON)
 option(Skyr_WARNINGS_AS_ERRORS "Treat warnings as errors." ON)
 option(Skyr_BUILD_WITHOUT_EXCEPTIONS "Build without exceptions." OFF)
 option(Skyr_USE_STATIC_CRT "Use static C Runtime library (/MT or MTd)." ON)
+option(Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS "Build the filesystem path functions" ON)
 option(Skyr_BUILD_WITH_LLVM_LIBCXX "Instruct Clang to use LLVM's implementation of C++ standard library" OFF)
 
 set(Skyr_WPT_TAG "merge_pr_22329" CACHE STRING "The Git tag for the WPT test data" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ option(Skyr_FULL_WARNINGS "Build the library with all warnings turned on." ON)
 option(Skyr_WARNINGS_AS_ERRORS "Treat warnings as errors." ON)
 option(Skyr_BUILD_WITHOUT_EXCEPTIONS "Build without exceptions." OFF)
 option(Skyr_USE_STATIC_CRT "Use static C Runtime library (/MT or MTd)." ON)
-option(Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS "Build the filesystem path functions" ON)
 option(Skyr_BUILD_WITH_LLVM_LIBCXX "Instruct Clang to use LLVM's implementation of C++ standard library" OFF)
 
 set(Skyr_WPT_TAG "merge_pr_22329" CACHE STRING "The Git tag for the WPT test data" )

--- a/examples/example_10.cpp
+++ b/examples/example_10.cpp
@@ -10,9 +10,5 @@ using namespace skyr::literals;
 
 int main(int argc, char *argv[]) {
   auto url = "https://example.org/?q=\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88&key=e1f7bc78"_url;
-  if (url) {
-    std::cout << url.value() << std::endl;
-  } else {
-    std::cerr << "Parsing failed: " << url.error().message() << std::endl;
-  }
+  std::cout << url << std::endl;
 }

--- a/include/skyr/unicode/constants.hpp
+++ b/include/skyr/unicode/constants.hpp
@@ -1,10 +1,12 @@
-// Copyright 2019 Glyn Matthews.
+// Copyright 2019-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef SKYR_UNICODE_CONSTANTS_HPP
 #define SKYR_UNICODE_CONSTANTS_HPP
+
+#include <array>
 
 namespace skyr {
 inline namespace v1 {
@@ -25,7 +27,7 @@ namespace code_points {
 constexpr char32_t max = 0x0010ffffu;
 }  // namespace code_points
 
-constexpr char bom[] = {'\xef', '\xbb', '\xbf'};
+constexpr std::array<char, 3> bom = {'\xef', '\xbb', '\xbf'};
 }  // namespace unicode::constants
 }  // namespace v1
 }  // namespace skyr

--- a/include/skyr/unicode/idna.hpp
+++ b/include/skyr/unicode/idna.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-19 Glyn Matthews.
+// Copyright 2018-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -38,13 +38,13 @@ enum class idna_status {
 ///
 /// \param code_point A code point value
 /// \return The status of the code point
-idna_status map_idna_status(char32_t code_point);
+auto map_idna_status(char32_t code_point) -> idna_status;
 
 ///
 /// \param code_point A code point value
 /// \return The code point or mapped value, depending on the status of the code
 /// point
-char32_t map_idna_code_point(char32_t code_point);
+auto map_idna_code_point(char32_t code_point) -> char32_t;
 }  // namespace unicode
 }  // namespace v1
 }  // namespace skyr

--- a/include/skyr/unicode/ranges/transforms/byte_transform.hpp
+++ b/include/skyr/unicode/ranges/transforms/byte_transform.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Glyn Matthews.
+// Copyright 2019-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -183,7 +183,7 @@ class transform_byte_range {
   /// Constructor
   /// \param range A range of code points
   explicit transform_byte_range(
-      const CodePointRange &range) noexcept
+      const CodePointRange &range)
       : first(iterator_type{std::begin(range), std::end(range)}),
         last(iterator_type{std::end(range), std::end(range)}) {}
 
@@ -232,7 +232,7 @@ struct byte_range_fn {
   /// \return
   template<class CodePointRange>
   constexpr auto operator()(
-      CodePointRange &&range) const noexcept {
+      CodePointRange &&range) const {
     return transform_byte_range{std::forward<CodePointRange>(range)};
   }
 
@@ -243,7 +243,7 @@ struct byte_range_fn {
   template<typename CodePointRange>
   friend constexpr auto operator|(
       CodePointRange &&range,
-      const byte_range_fn &) noexcept {
+      const byte_range_fn &) {
     return transform_byte_range{std::forward<CodePointRange>(range)};
   }
 };

--- a/include/skyr/unicode/ranges/transforms/u16_transform.hpp
+++ b/include/skyr/unicode/ranges/transforms/u16_transform.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Glyn Matthews.
+// Copyright 2019-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -117,12 +117,12 @@ class transform_u16_range {
   using size_type = std::size_t;
 
   /// Default constructor
-  constexpr transform_u16_range() noexcept = default;
+  constexpr transform_u16_range() = default;
 
   ///
   /// \param range
   explicit constexpr transform_u16_range(
-      CodePointRange &&range) noexcept
+      CodePointRange &&range)
       : range_{std::forward<CodePointRange>(range)} {}
 
   /// Returns an iterator to the beginning
@@ -175,7 +175,7 @@ struct transform_u16_range_fn {
   /// \return
   template <class CodePointRange>
   constexpr auto operator()(
-      CodePointRange &&range) const noexcept {
+      CodePointRange &&range) const {
     return transform_u16_range{std::forward<CodePointRange>(range)};
   }
 
@@ -186,7 +186,7 @@ struct transform_u16_range_fn {
   template <class CodePointRange>
   friend constexpr auto operator|(
       CodePointRange &&range,
-      const transform_u16_range_fn&) noexcept {
+      const transform_u16_range_fn&) {
     return transform_u16_range{std::forward<CodePointRange>(range)};
   }
 

--- a/include/skyr/unicode/ranges/transforms/u32_transform.hpp
+++ b/include/skyr/unicode/ranges/transforms/u32_transform.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Glyn Matthews.
+// Copyright 2019-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -106,11 +106,11 @@ class transform_u32_range {
   using size_type = std::size_t;
 
   ///
-  constexpr transform_u32_range() noexcept = default;
+  constexpr transform_u32_range() = default;
 
   ///
   /// \param range
-  explicit constexpr transform_u32_range(CodePointRange &&range) noexcept
+  explicit constexpr transform_u32_range(CodePointRange &&range)
       : range_(std::forward<CodePointRange>(range)) {}
 
   ///
@@ -163,7 +163,7 @@ struct transform_u32_range_fn {
   /// \return
   template <class CodePointRange>
   constexpr auto operator()(
-      CodePointRange &&range) const noexcept {
+      CodePointRange &&range) const {
     return transform_u32_range{std::forward<CodePointRange>(range)};
   }
 
@@ -174,7 +174,7 @@ struct transform_u32_range_fn {
   template <class CodePointRange>
   friend constexpr auto operator|(
       CodePointRange &&range,
-      const transform_u32_range_fn&) noexcept {
+      const transform_u32_range_fn&) {
     return transform_u32_range{std::forward<CodePointRange>(range)};
   }
 

--- a/include/skyr/unicode/ranges/views/u16_view.hpp
+++ b/include/skyr/unicode/ranges/views/u16_view.hpp
@@ -144,8 +144,8 @@ class view_u16_range {
 
   ///
   /// \param range
-  explicit constexpr view_u16_range(const U16Range &range) noexcept
-      : range_{range} {}
+  explicit constexpr view_u16_range(U16Range range) noexcept
+      : range_(std::move(range)) {}
 
   ///
   /// \return

--- a/include/skyr/unicode/ranges/views/u16_view.hpp
+++ b/include/skyr/unicode/ranges/views/u16_view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Glyn Matthews.
+// Copyright 2019-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -140,11 +140,11 @@ class view_u16_range {
   using size_type = std::size_t;
 
   ///
-  constexpr view_u16_range() noexcept = default;
+  constexpr view_u16_range() = default;
 
   ///
   /// \param range
-  explicit constexpr view_u16_range(U16Range range) noexcept
+  explicit constexpr view_u16_range(U16Range range)
       : range_(std::move(range)) {}
 
   ///
@@ -196,7 +196,7 @@ namespace view {
 /// \param range
 /// \return
 template <typename U16Range>
-inline auto as_u16(const U16Range &range) noexcept {
+inline auto as_u16(const U16Range &range) {
   static_assert(sizeof(typename traits::range_value<U16Range>::type) >= 1);
   return view_u16_range{range};
 }

--- a/include/skyr/unicode/ranges/views/u8_view.hpp
+++ b/include/skyr/unicode/ranges/views/u8_view.hpp
@@ -49,7 +49,7 @@ class u8_range_iterator {
   ///
   /// \param first
   /// \param last
-  explicit constexpr u8_range_iterator(
+  constexpr u8_range_iterator(
       OctetIterator first,
       OctetIterator last)
       : it_(iterator_type(first, last))

--- a/include/skyr/unicode/ranges/views/u8_view.hpp
+++ b/include/skyr/unicode/ranges/views/u8_view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Glyn Matthews.
+// Copyright 2019-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -145,11 +145,11 @@ class view_u8_range {
   using size_type = std::size_t;
 
   ///
-  constexpr view_u8_range() noexcept = default;
+  constexpr view_u8_range() = default;
 
   ///
   /// \param range
-  explicit constexpr view_u8_range(const OctetRange &range) noexcept
+  explicit constexpr view_u8_range(const OctetRange &range)
       : impl_(
       impl(std::begin(range),
            std::end(range))) {}
@@ -212,7 +212,7 @@ namespace view {
 /// \return
 template <typename OctetRange>
 inline auto as_u8(
-    const OctetRange &range) noexcept {
+    const OctetRange &range) {
   static_assert(sizeof(typename traits::range_value<OctetRange>::type) == 1);
   return view_u8_range{range};
 }

--- a/include/skyr/unicode/ranges/views/unchecked_u8_view.hpp
+++ b/include/skyr/unicode/ranges/views/unchecked_u8_view.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Glyn Matthews.
+// Copyright 2019-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -118,12 +118,12 @@ class view_unchecked_u8_range {
   using size_type = std::size_t;
 
   /// Default constructor
-  constexpr view_unchecked_u8_range() noexcept = default;
+  constexpr view_unchecked_u8_range() = default;
 
   ///
   /// \param range
   explicit constexpr view_unchecked_u8_range(
-      const OctetRange &range) noexcept
+      const OctetRange &range)
       : impl_(
       impl(std::begin(range),
            std::end(range))) {}
@@ -186,7 +186,7 @@ namespace view {
 /// \return
 template <typename OctetRange>
 inline auto unchecked_u8(
-    const OctetRange &range) noexcept {
+    const OctetRange &range) {
   return view_unchecked_u8_range{range};
 }
 }  // namespace view

--- a/include/skyr/url.hpp
+++ b/include/skyr/url.hpp
@@ -749,7 +749,7 @@ namespace literals {
 /// \param length
 /// \return A url
 inline auto operator "" _url(const char *str, std::size_t length) {
-  return make_url(std::string_view(str, length));
+  return url(std::string_view(str, length));
 }
 
 ///
@@ -757,7 +757,7 @@ inline auto operator "" _url(const char *str, std::size_t length) {
 /// \param length
 /// \return
 inline auto operator "" _url(const wchar_t *str, std::size_t length) {
-  return make_url(std::wstring_view(str, length));
+  return url(std::wstring_view(str, length));
 }
 
 ///
@@ -765,7 +765,7 @@ inline auto operator "" _url(const wchar_t *str, std::size_t length) {
 /// \param length
 /// \return
 inline auto operator "" _url(const char16_t *str, std::size_t length) {
-  return make_url(std::u16string_view(str, length));
+  return url(std::u16string_view(str, length));
 }
 
 ///
@@ -773,7 +773,7 @@ inline auto operator "" _url(const char16_t *str, std::size_t length) {
 /// \param length
 /// \return
 inline auto operator "" _url(const char32_t *str, std::size_t length) {
-  return make_url(std::u32string_view(str, length));
+  return url(std::u32string_view(str, length));
 }
 }  // namespace literals
 }  // namespace v1

--- a/include/skyr/url/filesystem.hpp
+++ b/include/skyr/url/filesystem.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Glyn Matthews.
+// Copyright 2018-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -6,8 +6,17 @@
 #ifndef SKYR_FILESYSTEM_PATH_HPP
 #define SKYR_FILESYSTEM_PATH_HPP
 
+#if !defined(__clang__) && (defined(__GNUC__) && __GNUC__ < 8)
+#define _LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM
+#define SKYR_USE_CXX17_EXPERIMENTAL_FILESYSTEM
+#endif // !defined(__clang__) && (defined(__GNUC__) && __GNUC__ < 8)
+
 #include <system_error>
+#if defined(SKYR_USE_CXX17_EXPERIMENTAL_FILESYSTEM)
+#include <experimental/filesystem>
+#else
 #include <filesystem>
+#endif // defined(SKYR_USE_CXX17_EXPERIMENTAL_FILESYSTEM)
 #include <tl/expected.hpp>
 #include <skyr/url.hpp>
 
@@ -17,12 +26,18 @@ inline namespace v1 {
 /// Contains functions to convert from filesystem path to URLs and
 /// vice versa
 namespace filesystem {
+#if defined(SKYR_USE_CXX17_EXPERIMENTAL_FILESYSTEM)
+namespace stdfs = std::experimental::filesystem;
+#else
+namespace stdfs = std::filesystem;
+#endif // defined(SKYR_USE_CXX17_EXPERIMENTAL_FILESYSTEM)
+
 ///
 enum class path_errc {
   ///
-      invalid_path = 1,
+  invalid_path = 1,
   ///
-      percent_decoding_error,
+  percent_decoding_error,
 };
 
 /// Creates a `std::error_code` given a `skyr::path_errc` value
@@ -34,12 +49,12 @@ std::error_code make_error_code(path_errc error) noexcept;
 /// some processing, including percent encoding
 /// \param path A filesystem path
 /// \returns a url object or an error on failure
-tl::expected<url, std::error_code> from_path(const std::filesystem::path &path);
+tl::expected<url, std::error_code> from_path(const stdfs::path &path);
 
 /// Converts a URL pathname to a filesystem path
 /// \param input A url object
 /// \returns a path object or an error on failure
-tl::expected<std::filesystem::path, std::error_code> to_path(const url &input);
+tl::expected<stdfs::path, std::error_code> to_path(const url &input);
 }  // namespace filesystem
 }  // namespace v1
 }  // namespace skyr

--- a/include/skyr/url/percent_encoding/percent_decode_range.hpp
+++ b/include/skyr/url/percent_encoding/percent_decode_range.hpp
@@ -58,19 +58,19 @@ class percent_decode_iterator {
   using difference_type = std::ptrdiff_t;
 
   ///
-  percent_decode_iterator() noexcept = default;
+  percent_decode_iterator() = default;
   ///
-  percent_decode_iterator(OctetIterator it, OctetIterator last) noexcept
+  percent_decode_iterator(OctetIterator it, OctetIterator last)
   : it_(it)
   , last_(last) {}
   ///
-  percent_decode_iterator(const percent_decode_iterator&) noexcept = default;
+  percent_decode_iterator(const percent_decode_iterator&) = default;
   ///
-  percent_decode_iterator(percent_decode_iterator&&) noexcept = default;
+  percent_decode_iterator(percent_decode_iterator&&) = default;
   ///
-  percent_decode_iterator &operator=(const percent_decode_iterator&)  noexcept = default;
+  percent_decode_iterator &operator=(const percent_decode_iterator&) = default;
   ///
-  percent_decode_iterator &operator=(percent_decode_iterator&&) noexcept = default;
+  percent_decode_iterator &operator=(percent_decode_iterator&&) = default;
   ///
   ~percent_decode_iterator() = default;
 
@@ -161,10 +161,10 @@ class percent_decode_range {
   using size_type = std::size_t;
 
   ///
-  percent_decode_range() noexcept = default;
+  percent_decode_range() = default;
   ///
   /// \param range
-  percent_decode_range(const OctetRange &range) noexcept
+  percent_decode_range(const OctetRange &range)
       : impl_(impl(std::begin(range), std::end(range))) {}
 
   ///
@@ -226,7 +226,7 @@ struct percent_decode_fn {
   /// \return
   template <typename OctetRange>
   constexpr auto operator()(
-      const OctetRange &range) const noexcept {
+      const OctetRange &range) const {
     return percent_decode_range{range};
   }
 
@@ -237,7 +237,7 @@ struct percent_decode_fn {
   template <typename OctetRange>
   friend constexpr auto operator|(
       const OctetRange &range,
-      const percent_decode_fn&) noexcept {
+      const percent_decode_fn&) {
     return percent_decode_range{range};
   }
 

--- a/include/skyr/url/percent_encoding/percent_encode_range.hpp
+++ b/include/skyr/url/percent_encoding/percent_encode_range.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Glyn Matthews.
+// Copyright 2019-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -36,24 +36,24 @@ class percent_encode_iterator {
   using difference_type = std::ptrdiff_t;
 
   ///
-  percent_encode_iterator() noexcept = default;
+  percent_encode_iterator() = default;
   ///
   /// \param it
   /// \param last
   /// \param excludes
   percent_encode_iterator(
       OctetIterator it,
-      OctetIterator last) noexcept
+      OctetIterator last)
   : it_(it)
   , last_(last) {}
   ///
-  percent_encode_iterator(const percent_encode_iterator &) noexcept = default;
+  percent_encode_iterator(const percent_encode_iterator &) = default;
   ///
-  percent_encode_iterator(percent_encode_iterator &&) noexcept = default;
+  percent_encode_iterator(percent_encode_iterator &&) = default;
   ///
-  percent_encode_iterator &operator=(const percent_encode_iterator &) noexcept = default;
+  percent_encode_iterator &operator=(const percent_encode_iterator &) = default;
   ///
-  percent_encode_iterator &operator=(percent_encode_iterator &&) noexcept = default;
+  percent_encode_iterator &operator=(percent_encode_iterator &&) = default;
   ///
   ~percent_encode_iterator() = default;
 
@@ -131,12 +131,12 @@ class percent_encode_range {
   using size_type = std::size_t;
 
   ///
-  percent_encode_range() noexcept = default;
+  percent_encode_range() = default;
   ///
   /// \param range
   /// \param excludes
   explicit percent_encode_range(
-      const OctetRange &range) noexcept
+      const OctetRange &range)
       : impl_(impl(std::begin(range), std::end(range))) {}
 
   ///
@@ -197,7 +197,7 @@ struct percent_encode_fn {
   /// \return
   template <typename OctetRange>
   constexpr auto operator()(
-      const OctetRange &range) const noexcept {
+      const OctetRange &range) const {
     return percent_encode_range{range};
   }
 
@@ -208,7 +208,7 @@ struct percent_encode_fn {
   template <typename OctetRange>
   friend constexpr auto operator|(
       const OctetRange &range,
-      const percent_encode_fn&) noexcept {
+      const percent_encode_fn&) {
     return percent_encode_range{range};
   }
 };

--- a/include/skyr/url/percent_encoding/percent_encoded_char.hpp
+++ b/include/skyr/url/percent_encoding/percent_encoded_char.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Glyn Matthews.
+// Copyright 2019-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -87,14 +87,14 @@ struct percent_encoded_char {
   struct no_encode {};
 
   ///
-  percent_encoded_char() noexcept = default;
+  percent_encoded_char() = default;
   ///
   /// \param byte
-  percent_encoded_char(char byte, no_encode) noexcept
+  percent_encoded_char(char byte, no_encode)
       : impl_{byte} {}
   ///
   /// \param byte
-  explicit percent_encoded_char(char byte) noexcept
+  explicit percent_encoded_char(char byte)
       : impl_{
       '%',
       details::hex_to_letter(static_cast<char>((static_cast<unsigned>(byte) >> 4u) & 0x0fu)),
@@ -102,11 +102,11 @@ struct percent_encoded_char {
   ///
   percent_encoded_char(const percent_encoded_char &) = default;
   ///
-  percent_encoded_char(percent_encoded_char &&) noexcept = default;
+  percent_encoded_char(percent_encoded_char &&) = default;
   ///
   percent_encoded_char &operator=(const percent_encoded_char &) = default;
   ///
-  percent_encoded_char &operator=(percent_encoded_char &&) noexcept = default;
+  percent_encoded_char &operator=(percent_encoded_char &&) = default;
   ///
   ~percent_encoded_char() = default;
 
@@ -158,7 +158,7 @@ struct percent_encoded_char {
 /// \param pred
 /// \return
 template <class Pred>
-inline percent_encoded_char percent_encode_byte(char byte, Pred pred) noexcept {
+inline percent_encoded_char percent_encode_byte(char byte, Pred pred) {
   if (pred(byte)) {
     return percent_encoding::percent_encoded_char(byte);
   }
@@ -170,7 +170,7 @@ inline percent_encoded_char percent_encode_byte(char byte, Pred pred) noexcept {
 /// \param byte
 /// \param excludes
 /// \return
-inline percent_encoded_char percent_encode_byte(char byte, encode_set excludes) noexcept {
+inline percent_encoded_char percent_encode_byte(char byte, encode_set excludes) {
   switch (excludes) {
     case encode_set::none:
       return percent_encoding::percent_encoded_char(byte);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set(Skyr_SRCS
         url/url.cpp
         url/url_error.cpp
         url/url_search_parameters.cpp
+        url/filesystem.cpp
         url/percent_encoding/errors.cpp
 
         ${Skyr_SOURCE_DIR}/include/skyr/config.hpp
@@ -56,12 +57,8 @@ set(Skyr_SRCS
         ${Skyr_SOURCE_DIR}/include/skyr/url/url_serialize.hpp
         ${Skyr_SOURCE_DIR}/include/skyr/url/url_error.hpp
         ${Skyr_SOURCE_DIR}/include/skyr/url/url_search_parameters.hpp
+        ${Skyr_SOURCE_DIR}/include/skyr/url/filesystem.hpp
         ${Skyr_SOURCE_DIR}/include/skyr/url.hpp)
-
-if (Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS)
-    LIST(APPEND Skyr_SRCS url/filesystem.cpp)
-    LIST(APPEND Skyr_SRCS ${Skyr_SOURCE_DIR}/include/skyr/url/filesystem.hpp)
-endif()
 
 add_library(skyr-url ${Skyr_SRCS})
 
@@ -71,9 +68,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
         target_link_libraries(skyr-url PUBLIC "c++")
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
-    if (Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS)
-        target_link_libraries(skyr-url PUBLIC "stdc++fs")
-    endif()
+    target_link_libraries(skyr-url PUBLIC "stdc++fs")
 endif()
 
 set_target_properties(skyr-url PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,6 @@ set(Skyr_SRCS
         url/url.cpp
         url/url_error.cpp
         url/url_search_parameters.cpp
-        url/filesystem.cpp
         url/percent_encoding/errors.cpp
 
         ${Skyr_SOURCE_DIR}/include/skyr/config.hpp
@@ -57,8 +56,12 @@ set(Skyr_SRCS
         ${Skyr_SOURCE_DIR}/include/skyr/url/url_serialize.hpp
         ${Skyr_SOURCE_DIR}/include/skyr/url/url_error.hpp
         ${Skyr_SOURCE_DIR}/include/skyr/url/url_search_parameters.hpp
-        ${Skyr_SOURCE_DIR}/include/skyr/url/filesystem.hpp
         ${Skyr_SOURCE_DIR}/include/skyr/url.hpp)
+
+if (Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS)
+    LIST(APPEND Skyr_SRCS url/filesystem.cpp)
+    LIST(APPEND Skyr_SRCS ${Skyr_SOURCE_DIR}/include/skyr/url/filesystem.hpp)
+endif()
 
 add_library(skyr-url ${Skyr_SRCS})
 
@@ -68,7 +71,9 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
         target_link_libraries(skyr-url PUBLIC "c++")
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
-    target_link_libraries(skyr-url PUBLIC "stdc++fs")
+    if (Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS)
+        target_link_libraries(skyr-url PUBLIC "stdc++fs")
+    endif()
 endif()
 
 set_target_properties(skyr-url PROPERTIES

--- a/src/unicode/idna.cpp
+++ b/src/unicode/idna.cpp
@@ -2839,7 +2839,7 @@ const code_point_range statuses[] = {
 };
 }  // namespace
 
-idna_status map_idna_status(char32_t code_point) {
+auto map_idna_status(char32_t code_point) -> idna_status {
   auto first = std::addressof(statuses[0]);
   auto last = first + (sizeof(statuses) / sizeof(statuses[0]));
   auto it = std::lower_bound(
@@ -8671,7 +8671,7 @@ const mapped_code_point mapped[] = {
 };
 }  // namespace
 
-char32_t map_idna_code_point(char32_t code_point) {
+auto map_idna_code_point(char32_t code_point) -> char32_t {
   auto first = std::addressof(mapped[0]);
   auto last = first + (sizeof(mapped) / sizeof(mapped[0]));
   auto it = std::lower_bound(

--- a/src/url/filesystem.cpp
+++ b/src/url/filesystem.cpp
@@ -32,11 +32,11 @@ std::error_code make_error_code(path_errc error) noexcept {
   return std::error_code(static_cast<int>(error), category);
 }
 
-tl::expected<url, std::error_code> from_path(const std::filesystem::path &path) {
+tl::expected<url, std::error_code> from_path(const stdfs::path &path) {
   return make_url("file://" + path.generic_u8string());
 }
 
-tl::expected<std::filesystem::path, std::error_code> to_path(const url &input) {
+tl::expected<stdfs::path, std::error_code> to_path(const url &input) {
   auto pathname = input.pathname();
   auto decoded = skyr::percent_encoding::as<std::string>(
       pathname | skyr::percent_encoding::view::decode);
@@ -44,7 +44,7 @@ tl::expected<std::filesystem::path, std::error_code> to_path(const url &input) {
     return tl::make_unexpected(
         make_error_code(path_errc::percent_decoding_error));
   }
-  return std::filesystem::path(decoded.value());
+  return stdfs::path(decoded.value());
 }
 }  // namespace filesystem
 }  // namespace v1

--- a/src/url/ipv4_address.cpp
+++ b/src/url/ipv4_address.cpp
@@ -7,7 +7,6 @@
 #include <cmath>
 #include <locale>
 #include <vector>
-#include <sstream>
 #include <algorithm>
 #include <optional>
 #include <cstdlib>

--- a/src/url/ipv6_address.cpp
+++ b/src/url/ipv6_address.cpp
@@ -65,7 +65,9 @@ inline std::uint16_t hex_to_dec(char byte) noexcept {
 }  // namespace
 
 std::string ipv6_address::to_string() const {
-  auto output = std::string();
+  using namespace std::string_literals;
+
+  auto output = ""s;
   auto compress = std::optional<size_t>();
 
   auto sequences = std::vector<std::pair<size_t, size_t>>();
@@ -120,7 +122,7 @@ std::string ipv6_address::to_string() const {
     }
 
     if (compress && (compress.value() == i)) {
-      auto separator = (i == 0) ? std::string("::") : std::string(":");
+      auto separator = (i == 0) ? "::"s : ":"s;
       output += separator;
       ignore0 = true;
       continue;

--- a/src/url/url_error.cpp
+++ b/src/url/url_error.cpp
@@ -11,11 +11,11 @@ inline namespace v1 {
 namespace {
 class url_parse_error_category : public std::error_category {
  public:
-  const char *name() const noexcept override {
+  [[nodiscard]] const char *name() const noexcept override {
     return "url parse";
   }
 
-  std::string message(int error) const noexcept override {
+  [[nodiscard]] std::string message(int error) const noexcept override {
     switch (static_cast<url_parse_errc>(error)) {
       case url_parse_errc::invalid_scheme_character:return "Invalid URL scheme";
       case url_parse_errc::not_an_absolute_url_with_fragment:return "Not an absolute URL with fragment";

--- a/src/url/url_parser_context.cpp
+++ b/src/url/url_parser_context.cpp
@@ -33,8 +33,9 @@ bool remove_tabs_and_newlines(std::string &input) {
 }
 
 inline bool is_forbidden_host_point(std::string_view::value_type byte) noexcept {
-  static const char forbidden[] = "\0\t\n\r #%/:?@[\\]";
-  const char *first = forbidden, *last = forbidden + sizeof(forbidden);
+  using namespace std::string_view_literals;
+  static const auto forbidden = "\0\t\n\r #%/:?@[\\]"sv;
+  auto first = begin(forbidden), last = end(forbidden);
   return last != std::find(first, last, byte);
 }
 

--- a/src/url/url_parser_context.hpp
+++ b/src/url/url_parser_context.hpp
@@ -51,7 +51,7 @@ class url_parser_context {
       const std::optional<url_record> &url,
       std::optional<url_parse_state> state_override = std::nullopt);
 
-  bool is_eof() const noexcept {
+  [[nodiscard]] bool is_eof() const noexcept {
     return it == end(view);
   }
 

--- a/tests/unicode/unicode_code_point_tests.cpp
+++ b/tests/unicode/unicode_code_point_tests.cpp
@@ -13,12 +13,13 @@
 TEST_CASE("u8 code point tests") {
   using std::begin;
   using std::end;
+  using namespace std::string_literals;
 
   SECTION("code point 01") {
-    auto bytes = std::string("\xf0\x9f\x92\xa9");
+    auto bytes = "\xf0\x9f\x92\xa9"s;
     auto cp = skyr::unicode::u8_code_point(bytes);
     REQUIRE(cp);
-    CHECK(std::string("\xf0\x9f\x92\xa9") == std::string(begin(cp.value()), end(cp.value())));
+    CHECK("\xf0\x9f\x92\xa9"s == std::string(begin(cp.value()), end(cp.value())));
     CHECK(U'\x1f4a9' == u32_value(cp));
     CHECK(u16_value(cp).value().is_surrogate_pair());
     CHECK(u'\xd83d' == u16_value(cp).value().lead_value());
@@ -26,7 +27,7 @@ TEST_CASE("u8 code point tests") {
   }
 
   SECTION("code point fail") {
-    auto bytes = std::string("\x9f\x92\xa9");
+    auto bytes = "\x9f\x92\xa9"s;
     auto cp = skyr::unicode::u8_code_point(bytes);
     REQUIRE(!cp);
   }

--- a/tests/unicode/unicode_range_tests.cpp
+++ b/tests/unicode/unicode_range_tests.cpp
@@ -18,10 +18,11 @@ namespace unicode = skyr::unicode;
 
 
 TEST_CASE("octet range iterator") {
-  using iterator_type = unicode::u8_range_iterator<std::string::const_iterator>;
+  using iterator_type = unicode::u8_range_iterator<std::string_view::const_iterator>;
+  using namespace std::string_view_literals;
 
   SECTION("construction") {
-    auto bytes = std::string("\xf0\x9f\x92\xa9");
+    const auto bytes = "\xf0\x9f\x92\xa9"sv;
     auto it = iterator_type(std::begin(bytes), std::end(bytes));
     auto code_point = *it;
     REQUIRE(code_point);
@@ -29,16 +30,16 @@ TEST_CASE("octet range iterator") {
   }
 
   SECTION("construction from array") {
-    char bytes[] = "\xf0\x9f\x92\xa9";
+    const auto bytes = "\xf0\x9f\x92\xa9"sv;
     auto first = std::begin(bytes), last = std::end(bytes);
-    auto it = unicode::u8_range_iterator<char *>(first, last);
+    auto it = unicode::u8_range_iterator<const char *>(first, last);
     auto code_point = *it;
     REQUIRE(code_point);
     CHECK(U'\x1F4A9' == u32_value(code_point.value()));
   }
 
   SECTION("increment") {
-    auto bytes = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto it = iterator_type(std::begin(bytes), std::end(bytes));
     auto code_point = *it;
     REQUIRE(code_point);
@@ -50,13 +51,13 @@ TEST_CASE("octet range iterator") {
   }
 
   SECTION("increment invalid") {
-    auto bytes = std::string("\xf0\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto it = iterator_type(std::begin(bytes), std::end(bytes));
     CHECK(!*it);
   }
 
   SECTION("equality") {
-    auto bytes = std::string("\xf0\x9f\x92\xa9");
+    const auto bytes = "\xf0\x9f\x92\xa9"sv;
     auto it = iterator_type(std::begin(bytes), std::end(bytes));
     auto last = iterator_type();
     ++it;
@@ -64,14 +65,14 @@ TEST_CASE("octet range iterator") {
   }
 
   SECTION("inequality") {
-    auto bytes = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto it = iterator_type(std::begin(bytes), std::end(bytes));
     auto last = iterator_type();
     CHECK(last != it);
   }
 
   SECTION("end of sequence") {
-    auto bytes = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto it = iterator_type(std::begin(bytes), std::end(bytes));
     auto last = iterator_type();
     std::advance(it, 4);
@@ -80,7 +81,7 @@ TEST_CASE("octet range iterator") {
 
   SECTION("two characters")
   {
-    auto bytes = std::string("\xe6\x97\xa5\xd1\x88");
+    const auto bytes = "\xe6\x97\xa5\xd1\x88"sv;
     auto it = iterator_type(std::begin(bytes), std::end(bytes));
     {
       auto code_point = *it++;
@@ -96,7 +97,7 @@ TEST_CASE("octet range iterator") {
 
   SECTION("three characters")
   {
-    auto bytes = std::string("\xf0\x90\x8d\x86\xe6\x97\xa5\xd1\x88");
+    const auto bytes = "\xf0\x90\x8d\x86\xe6\x97\xa5\xd1\x88"sv;
     auto it = iterator_type(std::begin(bytes), std::end(bytes));
     {
       auto code_point = *it++;
@@ -119,9 +120,10 @@ TEST_CASE("octet range iterator") {
 TEST_CASE("u8 range") {
   using std::begin;
   using std::end;
+  using namespace std::string_view_literals;
 
   SECTION("construction") {
-    auto bytes = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto view = unicode::view_u8_range(bytes);
     CHECK(begin(view) != end(view));
   }
@@ -132,7 +134,7 @@ TEST_CASE("u8 range") {
   }
 
   SECTION("count") {
-    auto bytes = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto view = unicode::view_u8_range(bytes);
     CHECK(4 == view.size());
     CHECK(!view.empty());
@@ -144,21 +146,21 @@ TEST_CASE("u8 range") {
   }
 
   SECTION("pipe syntax") {
-    auto bytes = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto view = unicode::view::as_u8(bytes);
     CHECK(4 == view.size());
     CHECK(!view.empty());
   }
 
   SECTION("pipe syntax with string_view") {
-    auto bytes = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto view = unicode::view::as_u8(std::string_view(bytes));
     CHECK(4 == view.size());
     CHECK(!view.empty());
   }
 
   SECTION("pipe syntax invalid") {
-    auto bytes = std::string("\xf0\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto view = unicode::view::as_u8(bytes);
     auto it = std::begin(view), last = std::end(view);
     CHECK(!*it++);
@@ -168,35 +170,37 @@ TEST_CASE("u8 range") {
   }
 
   SECTION("pipe syntax with u16 string") {
-    auto bytes = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto u16 = unicode::as<std::u16string>(unicode::view::as_u8(bytes) | unicode::transform::to_u16);
     REQUIRE(u16);
     CHECK(u"\xD83C\xDFF3\xFE0F\x200D\xD83C\xDF08" == u16.value());
   }
 
   SECTION("pipe syntax with u32 string") {
-    auto bytes = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto u32 = unicode::as<std::u32string>(unicode::view::as_u8(bytes) | unicode::transform::to_u32);
     REQUIRE(u32);
     CHECK(U"\x1F3F3\xFE0F\x200D\x1F308" == u32.value());
   }
 
   SECTION("pipe syntax with u16 string invalid") {
-    auto bytes = std::string("\xf0\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto u16 = unicode::as<std::u16string>(unicode::view::as_u8(bytes) | unicode::transform::to_u16);
     CHECK(!u16);
   }
 
   SECTION("pipe syntax with u32 string invalid") {
-    auto bytes = std::string("\xf0\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto bytes = "\xf0\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"sv;
     auto u32 = unicode::as<std::u32string>(unicode::view::as_u8(bytes) | unicode::transform::to_u32);
     CHECK(!u32);
   }
 }
 
 TEST_CASE("write bytes") {
+  using namespace std::string_literals;
+
   SECTION("bytes from u32") {
-    auto input = std::u32string(U"\x1F3F3\xFE0F\x200D\x1F308");
+    const auto input = U"\x1F3F3\xFE0F\x200D\x1F308"s;
     auto bytes = unicode::as<std::string>(
         input | unicode::transform::to_bytes);
     REQUIRE(bytes);
@@ -204,14 +208,14 @@ TEST_CASE("write bytes") {
   }
 
   SECTION("vector of bytes from u32") {
-    auto input = std::u32string(U"\x1F3F3\xFE0F\x200D\x1F308");
+    const auto input = U"\x1F3F3\xFE0F\x200D\x1F308"s;
     auto bytes = unicode::as<std::vector<std::byte>>(
         input | unicode::transform::to_bytes);
     REQUIRE(bytes);
   }
 
   SECTION("bytes from u16") {
-    auto input = std::u16string(u"\xD83C\xDFF3\xFE0F\x200D\xD83C\xDF08");
+    auto input = u"\xD83C\xDFF3\xFE0F\x200D\xD83C\xDF08"s;
     auto bytes = unicode::as<std::string>(
         unicode::view::as_u16(input) | unicode::transform::to_bytes);
     REQUIRE(bytes);

--- a/tests/unicode/unicode_tests.cpp
+++ b/tests/unicode/unicode_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-19 Glyn Matthews.
+// Copyright 2018-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -14,8 +14,10 @@
 
 
 TEST_CASE("unicode_tests", "[unicode]") {
+  using namespace std::string_literals;
+
   SECTION("utf32_to_bytes_poo_emoji_test") {
-    auto input = std::u32string(U"\x1F4A9");
+    const auto input = U"\x1F4A9"s;
     auto bytes = skyr::unicode::as<std::string>(
         input | skyr::unicode::transform::to_bytes);
     REQUIRE(bytes);
@@ -23,7 +25,7 @@ TEST_CASE("unicode_tests", "[unicode]") {
   }
 
   SECTION("bytes_to_utf32_poo_emoji_test") {
-    auto input = std::string("\xf0\x9f\x92\xa9");
+    const auto input = "\xf0\x9f\x92\xa9"s;
     auto utf32 = skyr::unicode::as<std::u32string>(
         skyr::unicode::view::as_u8(input) | skyr::unicode::transform::to_u32);
     REQUIRE(utf32);
@@ -31,7 +33,7 @@ TEST_CASE("unicode_tests", "[unicode]") {
   }
 
   SECTION("utf16_to_bytes_poo_emoji_test") {
-    auto input = std::u16string(u"\xd83d\xdca9");
+    const auto input = u"\xd83d\xdca9"s;
     auto bytes = skyr::unicode::as<std::string>(
         skyr::unicode::view::as_u16(input) | skyr::unicode::transform::to_bytes);
     REQUIRE(bytes);
@@ -39,7 +41,7 @@ TEST_CASE("unicode_tests", "[unicode]") {
   }
 
   SECTION("bytes_to_utf16_poo_emoji_test") {
-    auto input = std::string("\xf0\x9f\x92\xa9");
+    const auto input = "\xf0\x9f\x92\xa9"s;
     auto utf16 = skyr::unicode::as<std::u16string>(
         skyr::unicode::view::as_u8(input) | skyr::unicode::transform::to_u16);
     REQUIRE(utf16);
@@ -47,7 +49,7 @@ TEST_CASE("unicode_tests", "[unicode]") {
   }
 
   SECTION("wstring_to_bytes_poo_emoji_test") {
-    auto input = std::wstring(L"\xd83d\xdca9");
+    const auto input = L"\xd83d\xdca9"s;
     auto bytes = skyr::unicode::as<std::string>(
         skyr::unicode::view::as_u16(input) | skyr::unicode::transform::to_bytes);
     REQUIRE(bytes);
@@ -55,7 +57,7 @@ TEST_CASE("unicode_tests", "[unicode]") {
   }
 
   SECTION("bytes_to_wstring_poo_emoji_test") {
-    auto input = std::string("\xf0\x9f\x92\xa9");
+    const auto input = "\xf0\x9f\x92\xa9"s;
     auto utf16 = skyr::unicode::as<std::wstring>(
         skyr::unicode::view::as_u8(input) | skyr::unicode::transform::to_u16);
     REQUIRE(utf16);
@@ -63,7 +65,7 @@ TEST_CASE("unicode_tests", "[unicode]") {
   }
 
   SECTION("utf32_rainbow_flag_test") {
-    auto input = std::u32string(U"\x1F3F3\xFE0F\x200D\x1F308");
+    const auto input = U"\x1F3F3\xFE0F\x200D\x1F308"s;
     auto bytes = skyr::unicode::as<std::string>(
         input | skyr::unicode::transform::to_bytes);
     REQUIRE(bytes);

--- a/tests/url/CMakeLists.txt
+++ b/tests/url/CMakeLists.txt
@@ -19,13 +19,8 @@ set(
         ipv4_address_tests.cpp
         ipv6_address_tests.cpp
         url_literal_tests.cpp
+        filesystem_path_tests.cpp
     )
-
-if (Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS)
-    LIST(APPEND
-            URL_TESTS
-            filesystem_path_tests.cpp)
-endif()
 
 if (NOT Skyr_BUILD_WITHOUT_EXCEPTIONS)
     LIST(APPEND URL_TESTS

--- a/tests/url/CMakeLists.txt
+++ b/tests/url/CMakeLists.txt
@@ -19,8 +19,13 @@ set(
         ipv4_address_tests.cpp
         ipv6_address_tests.cpp
         url_literal_tests.cpp
-        filesystem_path_tests.cpp
     )
+
+if (Skyr_BUILD_FILESYSTEM_PATH_FUNCTIONS)
+    LIST(APPEND
+            URL_TESTS
+            filesystem_path_tests.cpp)
+endif()
 
 if (NOT Skyr_BUILD_WITHOUT_EXCEPTIONS)
     LIST(APPEND URL_TESTS

--- a/tests/url/filesystem_path_tests.cpp
+++ b/tests/url/filesystem_path_tests.cpp
@@ -38,7 +38,7 @@ TEST_CASE("filesystem path", "[filesystem_path]") {
   }
 
   SECTION("Windows path") {
-    auto path = std::filesystem::path("C:\\path\\to\\file.txt");
+    auto path = std::filesystem::path(R"(C:\path\to\file.txt)");
     auto url = skyr::filesystem::from_path(path);
     REQUIRE(url);
     CHECK(url.value().href() == "file:///C:/path/to/file.txt");

--- a/tests/url/filesystem_path_tests.cpp
+++ b/tests/url/filesystem_path_tests.cpp
@@ -8,6 +8,12 @@
 #include <skyr/url.hpp>
 #include <skyr/url/filesystem.hpp>
 
+#if defined(SKYR_USE_CXX17_EXPERIMENTAL_FILESYSTEM)
+namespace stdfs = std::experimental::filesystem;
+#else
+namespace stdfs = std::filesystem;
+#endif // defined(SKYR_USE_CXX17_EXPERIMENTAL_FILESYSTEM)
+
 TEST_CASE("filesystem path", "[filesystem_path]") {
   SECTION("empty_path") {
     auto instance = skyr::url{};
@@ -31,14 +37,14 @@ TEST_CASE("filesystem path", "[filesystem_path]") {
   }
 
   SECTION("from_path") {
-    auto path = std::filesystem::path("/path/to/file.txt");
+    auto path = stdfs::path("/path/to/file.txt");
     auto url = skyr::filesystem::from_path(path);
     REQUIRE(url);
     CHECK(url.value().href() == "file:///path/to/file.txt");
   }
 
   SECTION("Windows path") {
-    auto path = std::filesystem::path(R"(C:\path\to\file.txt)");
+    auto path = stdfs::path(R"(C:\path\to\file.txt)");
     auto url = skyr::filesystem::from_path(path);
     REQUIRE(url);
     CHECK(url.value().href() == "file:///C:/path/to/file.txt");

--- a/tests/url/ipv4_address_tests.cpp
+++ b/tests/url/ipv4_address_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-19 Glyn Matthews.
+// Copyright 2018-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt of copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -8,6 +8,8 @@
 #include "../../src/url/ipv4_address.hpp"
 
 TEST_CASE("ipv4 addresses", "[ipv4]") {
+  using namespace std::string_literals;
+
   SECTION("zero_test") {
     auto instance = skyr::ipv4_address(0);
     CHECK("0.0.0.0" == instance.to_string());
@@ -24,35 +26,35 @@ TEST_CASE("ipv4 addresses", "[ipv4]") {
   }
 
   SECTION("parse_zero_test") {
-    auto address = std::string("0.0.0.0");
+    const auto address = "0.0.0.0"s;
     auto instance = skyr::parse_ipv4_address(address);
     REQUIRE(instance);
     CHECK(0 == instance.value().address());
   }
 
   SECTION("parse_loopback_test") {
-    auto address = std::string("127.0.0.1");
+    const auto address = "127.0.0.1"s;
     auto instance = skyr::parse_ipv4_address(address);
     REQUIRE(instance);
     CHECK(0x7f000001 == instance.value().address());
   }
 
   SECTION("parse_address_test") {
-    auto address = std::string("129.79.245.252");
+    const auto address = "129.79.245.252"s;
     auto instance = skyr::parse_ipv4_address(address);
     REQUIRE(instance);
     CHECK(0x814ff5fc == instance.value().address());
   }
 
   SECTION("parse_address_with_hex") {
-    auto address = std::string("0x7f.0.0.0x7f");
+    const auto address = "0x7f.0.0.0x7f"s;
     auto instance = skyr::parse_ipv4_address(address);
     REQUIRE(instance);
     CHECK(0x7f00007f == instance.value().address());
   }
 
   SECTION("parse_invalid_address_with_hex") {
-    auto address = std::string("0x7f.0.0.0x7g");
+    const auto address = "0x7f.0.0.0x7g"s;
     auto instance = skyr::parse_ipv4_address(address);
     REQUIRE_FALSE(instance);
   }

--- a/tests/url/ipv6_address_tests.cpp
+++ b/tests/url/ipv6_address_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-19 Glyn Matthews.
+// Copyright 2018-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt of copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -8,6 +8,8 @@
 #include "../../src/url/ipv6_address.hpp"
 
 TEST_CASE("ipv6_address_tests", "[ipv6]") {
+  using namespace std::string_literals;
+
   SECTION("zero_test") {
     auto address = std::array<unsigned short, 8>{{0, 0, 0, 0, 0, 0, 0, 0}};
     auto instance = skyr::ipv6_address(address);
@@ -21,112 +23,112 @@ TEST_CASE("ipv6_address_tests", "[ipv6]") {
   }
 
   SECTION("ipv6_address_test_1") {
-    auto address = std::string("1080:0:0:0:8:800:200C:417A");
+    const auto address = "1080:0:0:0:8:800:200C:417A"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("1080::8:800:200c:417a" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_2") {
-    auto address = std::string("2001:db8:85a3:8d3:1319:8a2e:370:7348");
+    const auto address = "2001:db8:85a3:8d3:1319:8a2e:370:7348"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("2001:db8:85a3:8d3:1319:8a2e:370:7348" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_3") {
-    auto address = std::string("2001:db8:85a3:0:0:8a2e:370:7334");
+    const auto address = "2001:db8:85a3:0:0:8a2e:370:7334"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("2001:db8:85a3::8a2e:370:7334" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_4") {
-    auto address = std::string("2001:db8:85a3::8a2e:370:7334");
+    const auto address = "2001:db8:85a3::8a2e:370:7334"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("2001:db8:85a3::8a2e:370:7334" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_5") {
-    auto address = std::string("2001:0db8:0000:0000:0000:0000:1428:57ab");
+    const auto address = "2001:0db8:0000:0000:0000:0000:1428:57ab"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("2001:db8::1428:57ab" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_6") {
-    auto address = std::string("2001:0db8:0000:0000:0000::1428:57ab");
+    const auto address = "2001:0db8:0000:0000:0000::1428:57ab"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("2001:db8::1428:57ab" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_7") {
-    auto address = std::string("2001:0db8:0:0:0:0:1428:57ab");
+    const auto address = "2001:0db8:0:0:0:0:1428:57ab"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("2001:db8::1428:57ab" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_8") {
-    auto address = std::string("2001:0db8:0:0::1428:57ab");
+    const auto address = "2001:0db8:0:0::1428:57ab"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("2001:db8::1428:57ab" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_9") {
-    auto address = std::string("2001:0db8::1428:57ab");
+    const auto address = "2001:0db8::1428:57ab"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("2001:db8::1428:57ab" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_10") {
-    auto address = std::string("2001:db8::1428:57ab");
+    const auto address = "2001:db8::1428:57ab"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("2001:db8::1428:57ab" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_11") {
-    auto address = std::string("::ffff:0c22:384e");
+    const auto address = "::ffff:0c22:384e"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("::ffff:c22:384e" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_12") {
-    auto address = std::string("fe80::");
+    const auto address = "fe80::"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("fe80::" == instance.value().to_string());
   }
 
   SECTION("ipv6_address_test_13") {
-    auto address = std::string("::ffff:c000:280");
+    const auto address = "::ffff:c000:280"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("::ffff:c000:280" == instance.value().to_string());
   }
 
   SECTION("ipv6_loopback_test_1") {
-    auto address = std::string("0000:0000:0000:0000:0000:0000:0000:0001");
+    const auto address = "0000:0000:0000:0000:0000:0000:0000:0001"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("::1" == instance.value().to_string());
   }
 
   SECTION("ipv6_v4inv6_test_1") {
-    auto address = std::string("::ffff:12.34.56.78");
+    const auto address = "::ffff:12.34.56.78"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("::ffff:c22:384e" == instance.value().to_string());
   }
 
   SECTION("ipv6_v4inv6_test_2") {
-    auto address = std::string("::ffff:192.0.2.128");
+    const auto address = "::ffff:192.0.2.128"s;
     auto instance = skyr::parse_ipv6_address(address);
     REQUIRE(instance);
     CHECK("::ffff:c000:280" == instance.value().to_string());

--- a/tests/url/percent_decoding_tests.cpp
+++ b/tests/url/percent_decoding_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-19 Glyn Matthews.
+// Copyright 2018-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -11,11 +11,13 @@
 
 
 TEST_CASE("percent_decode", "[percent_decode]") {
+  using namespace std::string_literals;
+
   SECTION("decode_codepoints_set") {
     for (auto i = 0x00; i < 0xff; ++i) {
       char buffer[8];
       std::snprintf(buffer, sizeof(buffer), "%02X", i);
-      auto input = std::string("%") + buffer;
+      const auto input = "%"s + buffer;
       auto decoded = skyr::percent_encoding::as<std::string>(
           input | skyr::percent_encoding::view::decode);
       REQUIRE(decoded);
@@ -24,7 +26,7 @@ TEST_CASE("percent_decode", "[percent_decode]") {
   }
 
   SECTION("u8_test") {
-    auto input = std::string("%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88");
+    const auto input = "%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88"s;
     auto decoded = skyr::percent_encoding::as<std::string>(
         input | skyr::percent_encoding::view::decode);
     REQUIRE(decoded);
@@ -32,7 +34,7 @@ TEST_CASE("percent_decode", "[percent_decode]") {
   }
 
   SECTION("empty string") {
-    auto input = std::string();
+    const auto input = ""s;
     auto decoded = skyr::percent_encoding::as<std::string>(
         input | skyr::percent_encoding::view::decode);
     CHECK(decoded);

--- a/tests/url/percent_encoding_tests.cpp
+++ b/tests/url/percent_encoding_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-19 Glyn Matthews.
+// Copyright 2018-20 Glyn Matthews.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -39,12 +39,14 @@ TEST_CASE("encode userinfo", "[percent_encoding]") {
 }
 
 TEST_CASE("encode_tests", "[percent_encoding]") {
+  using namespace std::string_literals;
+
   SECTION("encode_codepoints_before_0x20_set") {
     for (auto i = 0u; i < 0x20u; ++i) {
       auto encoded = skyr::percent_encoding::percent_encode_byte(i, skyr::percent_encoding::encode_set::c0_control);
       char buffer[8];
       std::snprintf(buffer, sizeof(buffer), "%02X", i);
-      auto output = std::string("%") + buffer;
+      auto output = "%"s + buffer;
       CHECK(output == encoded.to_string());
     }
   }
@@ -54,20 +56,20 @@ TEST_CASE("encode_tests", "[percent_encoding]") {
       auto encoded = skyr::percent_encoding::percent_encode_byte(i, skyr::percent_encoding::encode_set::c0_control);
       char buffer[8];
       std::snprintf(buffer, sizeof(buffer), "%02X", i);
-      auto output = std::string("%") + buffer;
+      auto output = "%"s + buffer;
       CHECK(output == encoded.to_string());
     }
   }
 
   SECTION("u8_test_1") {
-    auto input = std::string("\xf0\x9f\x92\xa9");
+    const auto input = "\xf0\x9f\x92\xa9"s;
     auto encoded = skyr::percent_encoding::as<std::string>(input | skyr::percent_encoding::view::encode);
     REQUIRE(encoded);
     CHECK("%F0%9F%92%A9" == encoded.value());
   }
 
   SECTION("u8_test_2") {
-    auto input = std::string("\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88");
+    const auto input = "\xf0\x9f\x8f\xb3\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x8c\x88"s;
     auto encoded = skyr::percent_encoding::as<std::string>(input | skyr::percent_encoding::view::encode);
     REQUIRE(encoded);
     CHECK("%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%F0%9F%8C%88" == encoded.value());

--- a/tests/url/url_literal_tests.cpp
+++ b/tests/url/url_literal_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Glyn Matthews
+// Copyright 2019-20 Glyn Matthews
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt of copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -13,18 +13,18 @@ using namespace skyr::literals;
 
 TEST_CASE("url_tests", "[url]") {
   SECTION("construct url from literal") {
-    CHECK("http://www.example.com/"_url);
+    CHECK_NOTHROW("http://www.example.com/"_url);
   }
 
   SECTION("construct url from wchar_t literal") {
-    CHECK(L"http://www.example.com/"_url);
+    CHECK_NOTHROW(L"http://www.example.com/"_url);
   }
 
   SECTION("construct url from char16_t literal") {
-    CHECK(u"http://www.example.com/"_url);
+    CHECK_NOTHROW(u"http://www.example.com/"_url);
   }
 
   SECTION("construct url from char32_t literal") {
-    CHECK(U"http://www.example.com/"_url);
+    CHECK_NOTHROW(U"http://www.example.com/"_url);
   }
 }

--- a/tests/url/url_parsing_example_tests.cpp
+++ b/tests/url/url_parsing_example_tests.cpp
@@ -11,6 +11,8 @@
 /// https://url.spec.whatwg.org/#example-url-parsing
 
 TEST_CASE("url_parsing_example_tests", "[parse]") {
+  using namespace std::string_literals;
+
   SECTION("url_path_1") {
     auto instance = skyr::parse("https:example.org");
     REQUIRE(instance);
@@ -24,8 +26,7 @@ TEST_CASE("url_parsing_example_tests", "[parse]") {
   }
 
   SECTION("url_serialize_1") {
-    auto input = std::string("https:example.org");
-    auto instance = skyr::parse(input);
+    auto instance = skyr::parse("https:example.org");
     REQUIRE(instance);
     auto output = skyr::serialize(instance.value());
     CHECK("https://example.org/" == output);
@@ -66,7 +67,7 @@ TEST_CASE("url_parsing_example_tests", "[parse]") {
   SECTION("url_serialize_6") {
     auto base = skyr::parse("https://example.com/");
     REQUIRE(base);
-    auto instance = skyr::parse("\\example\\..\\demo/.\\", base.value());
+    auto instance = skyr::parse(R"(\example\..\demo/.\)", base.value());
     REQUIRE(instance);
     auto output = skyr::serialize(instance.value());
     CHECK("https://example.com/demo/" == output);

--- a/tests/url/url_tests.cpp
+++ b/tests/url/url_tests.cpp
@@ -1,5 +1,5 @@
 // Copyright 2010 Jeroen Habraken.
-// Copyright 2009-2019 Dean Michael Berris, Glyn Matthews.
+// Copyright 2009-2020 Dean Michael Berris, Glyn Matthews.
 // Copyright 2012 Google, Inc.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt of copy at
@@ -12,6 +12,8 @@
 #include <skyr/url.hpp>
 
 TEST_CASE("url_tests", "[url]") {
+  using namespace std::string_literals;
+
   SECTION("construct_invalid_url_make") {
     CHECK_FALSE(skyr::make_url("I am not a valid url."));
   }
@@ -37,7 +39,7 @@ TEST_CASE("url_tests", "[url]") {
   }
 
   SECTION("construct_url_from_string_make") {
-    auto input = std::string("http://www.example.com/");
+    const auto input = "http://www.example.com/"s;
     CHECK(skyr::make_url(input));
   }
 

--- a/tests/url/url_tests_with_exceptions.cpp
+++ b/tests/url/url_tests_with_exceptions.cpp
@@ -12,6 +12,8 @@
 #include <skyr/url.hpp>
 
 TEST_CASE("url_tests", "[url]") {
+  using namespace std::string_literals;
+
   SECTION("construct_invalid_url") {
     CHECK_THROWS_AS(skyr::url("I am not a valid url."), skyr::url_parse_error);
   }
@@ -37,7 +39,7 @@ TEST_CASE("url_tests", "[url]") {
   }
 
   SECTION("construct_url_from_string") {
-    auto input = std::string("http://www.example.com/");
+    const auto input = "http://www.example.com/"s;
     CHECK_NOTHROW((skyr::url(input)));
   }
 

--- a/tests/url/wpt/url_web_platform_tests.cpp
+++ b/tests/url/wpt/url_web_platform_tests.cpp
@@ -77,7 +77,7 @@ class TestCaseGenerator : public Catch::Generators::IGenerator<test_case> {
     it_ = begin(test_case_data_);
   }
 
-  const test_case &get() const override {
+  [[nodiscard]] const test_case &get() const override {
     assert(it_ != test_case_data_.end());
     return *it_;
   }

--- a/tests/url/wpt/url_web_platform_tests_with_exceptions.cpp
+++ b/tests/url/wpt/url_web_platform_tests_with_exceptions.cpp
@@ -77,7 +77,7 @@ class TestCaseGenerator : public Catch::Generators::IGenerator<test_case> {
     it_ = begin(test_case_data_);
   }
 
-  const test_case &get() const override {
+  [[nodiscard]] const test_case &get() const override {
     assert(it_ != test_case_data_.end());
     return *it_;
   }

--- a/tools/make_idna_table.py
+++ b/tools/make_idna_table.py
@@ -75,7 +75,7 @@ def main():
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <algorithm>
-#include <skyr/unicode/idna_table.hpp>
+#include <skyr/unicode/idna.hpp>
 
 namespace skyr {
 inline namespace v1 {
@@ -92,7 +92,7 @@ const code_point_range statuses[] = {
 {% endfor %}};
 }  // namespace
 
-idna_status map_idna_status(char32_t code_point) {
+auto map_idna_status(char32_t code_point) -> idna_status {
   auto first = std::addressof(statuses[0]);
   auto last = first + (sizeof(statuses) / sizeof(statuses[0]));
   auto it = std::lower_bound(
@@ -114,7 +114,7 @@ const mapped_code_point mapped[] = {
 {% endif %}{% endfor %}};
 }  // namespace
 
-char32_t map_idna_code_point(char32_t code_point) {
+auto map_idna_code_point(char32_t code_point) -> char32_t {
   auto first = std::addressof(mapped[0]);
   auto last = first + (sizeof(mapped) / sizeof(mapped[0]));
   auto it = std::lower_bound(


### PR DESCRIPTION
This PR contains changes to support compilation on GCC 7, as well as changes based on feedback from running clang-tidy.